### PR TITLE
Drop support for PHP 8.2

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,7 +8,7 @@ on:
         required: false
         type: string
       PHP_VERSIONS:
-        default: '8.2,8.3,8.4'
+        default: '8.3,8.4'
         required: false
         type: string
       SYMFONY_VERSIONS:


### PR DESCRIPTION
Dropping support for PHP version that has only active security support.